### PR TITLE
Remove extra argument from thumbnail sync call

### DIFF
--- a/makerworks-backend/app/routes/auth.py
+++ b/makerworks-backend/app/routes/auth.py
@@ -82,7 +82,7 @@ async def signin(payload: UserSignIn, request: Request, response: Response, db: 
 
     # ✅ Ensure thumbnails are synced for this user
     try:
-        ensure_user_model_thumbnails_for_user(str(user.id), user_models_path)
+        ensure_user_model_thumbnails_for_user(str(user.id))
     except Exception as e:
         logger.error(f"[AUTH] Thumbnail synchronization failed: {e}")
 


### PR DESCRIPTION
## Summary
- remove unused `user_models_path` parameter from `ensure_user_model_thumbnails_for_user` call in `auth.py`

## Testing
- `python -m py_compile makerworks-backend/app/routes/auth.py`
- `pytest -q` *(fails: Database schema out of sync)*

------
https://chatgpt.com/codex/tasks/task_e_688cb57a0ee4832fbb59c8c02551d870

## Summary by Sourcery

Enhancements:
- Remove extra argument from ensure_user_model_thumbnails_for_user invocation in auth route