### PR TITLE
Update Redis defaults

### DIFF
--- a/makerworks-backend/.env.example
+++ b/makerworks-backend/.env.example
@@ -23,9 +23,9 @@ AVATAR_DIR=./avatars
 DATABASE_URL=postgresql+asyncpg://postgres:password@localhost:5432/makerworks
 
 # 📄 Redis & Celery
-REDIS_URL=redis://localhost:6379/0
-CELERY_BROKER_URL=redis://localhost:6379/0
-CELERY_RESULT_BACKEND=redis://localhost:6379/0
+REDIS_URL=redis://redis:6379/0
+CELERY_BROKER_URL=redis://redis:6379/0
+CELERY_RESULT_BACKEND=redis://redis:6379/0
 CELERY_ENABLED=false
 
 # 📄 JWT (legacy - not used when using Redis sessions)

--- a/makerworks-backend/app/utils/logging.py
+++ b/makerworks-backend/app/utils/logging.py
@@ -138,7 +138,7 @@ def startup_banner():
     memory_percent_gauge.set(mem.percent)
 
     # Redis check
-    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
+    redis_url = os.getenv("REDIS_URL", "redis://redis:6379")
     redis_status = check_redis_available(redis_url)
     redis_text = f"{'✅ Connected' if redis_status else '❌ Unavailable'}"
     logger.info(


### PR DESCRIPTION
## Summary
- update `.env.example` to point Celery & Redis at `redis:6379`
- set default Redis URL in logging utility to the new host

## Testing
- `pytest -q` *(fails: 17 failed, 3 passed, 1 error)*
- `docker-compose up -d worker` *(fails: Docker daemon not running)*

------
https://chatgpt.com/codex/tasks/task_e_688ceb77b14c832f9977ac035e28a493