### PR TITLE
Add pytest config for asyncio

### DIFF
--- a/makerworks-backend/pytest.ini
+++ b/makerworks-backend/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto


### PR DESCRIPTION
## Summary
- configure pytest to use pytest-asyncio's auto mode in backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cefbc804c832fb42dfa313d9bac41

## Summary by Sourcery

Tests:
- Add pytest.ini file setting asyncio_mode to auto for pytest-asyncio