### PR TITLE
Implement G‑code generation task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ env/
 package-lock.json
 yarn-error.log
 .pnpm-debug.log
+makerworks-backend/test_avatar.db

--- a/makerworks-backend/app/tasks/render.py
+++ b/makerworks-backend/app/tasks/render.py
@@ -1,14 +1,46 @@
 import logging
+from pathlib import Path
 
 from app.worker import celery_app
+from app.config.settings import settings
 
 logger = logging.getLogger(__name__)
 
 
-@celery_app.task
-def generate_gcode(model_id: int, estimate_id: int):
+@celery_app.task(bind=True, name="generate_gcode")
+def generate_gcode(self, model_id: int, estimate_id: int):
+    """Generate a simple G-code file for a model/estimate pair.
+
+    The task writes a basic square path to ``uploads/gcode``. This is not a
+    full slicer implementation but provides functional output for testing.
+    """
+
     logger.info(
         "[TASK] Generating G-code for model %s, estimate %s", model_id, estimate_id
     )
-    # TODO: Actual G-code rendering logic
-    return True
+
+    gcode_dir = Path(settings.uploads_path) / "gcode"
+    gcode_dir.mkdir(parents=True, exist_ok=True)
+    output_path = gcode_dir / f"{model_id}_{estimate_id}.gcode"
+
+    try:
+        with output_path.open("w") as fh:
+            fh.write("; MakerWorks auto-generated G-code\n")
+            fh.write("G90 ; absolute positioning\n")
+            fh.write("M82 ; absolute extrusion\n")
+            for layer in range(5):
+                z = layer * 0.2
+                fh.write(f"G1 Z{z:.2f} F3000\n")
+                fh.write("G1 X0 Y0\n")
+                fh.write("G1 X10 Y0\n")
+                fh.write("G1 X10 Y10\n")
+                fh.write("G1 X0 Y10\n")
+                fh.write("G1 X0 Y0\n")
+            fh.write("M104 S0\n")
+            fh.write("M140 S0\n")
+            fh.write("M84\n")
+        logger.info("✅ G-code generated: %s", output_path)
+        return str(output_path)
+    except Exception as exc:
+        logger.exception("❌ G-code generation failed")
+        raise exc

--- a/makerworks-backend/tests/test_gcode_task.py
+++ b/makerworks-backend/tests/test_gcode_task.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import importlib
+from pathlib import Path
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("ENV", "test")
+os.environ.setdefault("DOMAIN", "http://testserver")
+os.environ.setdefault("BASE_URL", "http://testserver")
+os.environ.setdefault("VITE_API_BASE_URL", "http://testserver")
+os.environ.setdefault("ASYNC_DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("JWT_SECRET", "secret")
+
+
+def test_generate_gcode_creates_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("UPLOADS_PATH", str(tmp_path))
+    # Import after setting env so settings uses tmp path
+    task_module = importlib.import_module("app.tasks.render")
+    importlib.reload(task_module)
+    output = task_module.generate_gcode(model_id=1, estimate_id=2)
+    expected = Path(tmp_path) / "gcode" / "1_2.gcode"
+    assert output == str(expected)
+    assert expected.exists()
+    # Check file contains some G-code commands
+    content = expected.read_text()
+    assert "G90" in content


### PR DESCRIPTION
## Summary
- implement basic G-code writer in `generate_gcode` Celery task
- add unit test for new G-code task
- ignore temporary test database file

## Testing
- `pytest tests/test_gcode_task.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688d20609538832fba74b96255c37430