### PR TITLE
Mock axios in Estimate tests

### DIFF
--- a/makerworks-frontend/src/store/__tests__/Estimate.test.tsx
+++ b/makerworks-frontend/src/store/__tests__/Estimate.test.tsx
@@ -7,6 +7,7 @@ expect.extend(matchers);
 import Estimate from '../../pages/Estimate';
 import axios from '@/api/axios';
 import * as estimateApi from '@/api/estimate';
+vi.mock('@/api/axios', () => ({ default: { get: vi.fn() } }))
 vi.mock('@/components/ui/ModelViewer', () => ({
   default: () => <div data-testid="model-viewer" />,
 }));
@@ -21,6 +22,7 @@ describe('<Estimate />', () => {
   beforeEach(() => {
     // jsdom doesn't implement scrollTo
     window.scrollTo = vi.fn();
+    ;(axios.get as any).mockResolvedValue({ data: [] })
   });
   it('renders page header', () => {
     render(<Estimate />);


### PR DESCRIPTION
## Summary
- mock axios `get` in `Estimate.test.tsx` to block real requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d23e5c9e8832f8d19e007cc7ec63c