### PR TITLE
Refactor validators for Pydantic v2

### DIFF
--- a/makerworks-backend/app/routes/models.py
+++ b/makerworks-backend/app/routes/models.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, status, Query, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from app.config.settings import settings
 from app.db.session import get_db
@@ -27,8 +27,7 @@ class ModelItem(BaseModel):
     thumbnail_url: Optional[str]
     webm_url: Optional[str]
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class PaginatedModelListResponse(BaseModel):

--- a/makerworks-backend/app/schemas/admin.py
+++ b/makerworks-backend/app/schemas/admin.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, ConfigDict
 
 
 class UserOut(BaseModel):
@@ -17,8 +17,7 @@ class UserOut(BaseModel):
     created_at: Optional[datetime]
     last_login: Optional[datetime]
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class UploadOut(BaseModel):
@@ -30,8 +29,7 @@ class UploadOut(BaseModel):
     thumbnail_url: Optional[str]
     status: Optional[str]
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class DiscordConfigOut(BaseModel):
@@ -39,5 +37,4 @@ class DiscordConfigOut(BaseModel):
     channel_id: str
     enabled: bool
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)

--- a/makerworks-backend/app/schemas/models.py
+++ b/makerworks-backend/app/schemas/models.py
@@ -1,8 +1,8 @@
 # app/schemas/models.py
 
 from datetime import datetime
-from typing import Optional, List
-from pydantic import BaseModel, Field, constr, validator
+from typing import Optional
+from pydantic import BaseModel, Field, constr, field_validator, ConfigDict
 import os
 import re
 
@@ -60,12 +60,12 @@ class ModelOut(ModelBase):
     geometry_hash: Optional[str] = None
     is_duplicate: Optional[bool] = None
 
-    @validator('thumbnail_url', 'file_url', pre=True, always=True)
+    @field_validator('thumbnail_url', 'file_url', mode='before')
+    @classmethod
     def normalize_urls(cls, v):
         return _normalize_media_url(v)
 
-    class Config:
-        from_attributes = True  # ✅ Pydantic v2 replacement for orm_mode
+    model_config = ConfigDict(from_attributes=True)  # ✅ Pydantic v2
 
 # =========================
 # Upload Request/Response
@@ -91,7 +91,8 @@ class ModelUploadResponse(BaseModel):
     geometry_hash: Optional[str] = None
     is_duplicate: Optional[bool] = None
 
-    @validator('thumbnail_url', 'file_url', pre=True, always=True)
+    @field_validator('thumbnail_url', 'file_url', mode='before')
+    @classmethod
     def normalize_urls(cls, v):
         if not v:
             return v
@@ -99,8 +100,7 @@ class ModelUploadResponse(BaseModel):
         filename = re.sub(r"\?.*$", "", filename)
         return f"/media/{filename}"
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 # =========================
 # Model Upload Output Schema
@@ -121,9 +121,9 @@ class ModelUploadOut(BaseModel):
     uploaded_at: datetime = Field(..., description="UTC timestamp of upload")
     job_id: Optional[str] = Field(None, description="Celery job ID for preview rendering")
 
-    @validator('thumbnail', 'file_path', pre=True, always=True)
+    @field_validator('thumbnail', 'file_path', mode='before')
+    @classmethod
     def normalize_urls(cls, v):
         return _normalize_media_url(v)
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)

--- a/makerworks-backend/app/schemas/user.py
+++ b/makerworks-backend/app/schemas/user.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from uuid import UUID
 from typing import Optional
-from pydantic import BaseModel, EmailStr, HttpUrl, field_serializer
+from pydantic import BaseModel, EmailStr, HttpUrl, field_serializer, ConfigDict
 
 
 class UserOut(BaseModel):
@@ -29,8 +29,7 @@ class UserOut(BaseModel):
     def serialize_datetime(self, v: datetime | None, _info) -> Optional[str]:
         return v.isoformat() if v else None
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class UpdateUserProfile(BaseModel):
@@ -39,8 +38,7 @@ class UpdateUserProfile(BaseModel):
     language: Optional[str] = None
     avatar_url: Optional[HttpUrl] = None  # ✅ Allow avatar updates
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class AvatarUploadResponse(BaseModel):


### PR DESCRIPTION
## Summary
- migrate model schemas to `field_validator`
- replace deprecated `Config` usage with `model_config`
- update routes model item config

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_688d252cf788832fbed8d45b4d4e0b9a