### PR TITLE
Align upload paths under /uploads/users

### DIFF
--- a/makerworks-backend/app/celery_worker.py
+++ b/makerworks-backend/app/celery_worker.py
@@ -113,17 +113,20 @@ def render_thumbnail_task(model_id_or_path: str):
     from app.db.session import get_sync_session
     from app.models.models import Model
     from app.utils.render_thumbnail import render_thumbnail
+    from app.config.settings import settings
 
     candidate = pathlib.Path(model_id_or_path)
     if candidate.exists():
-        return render_thumbnail(str(candidate))
+        output = candidate.with_suffix("_thumb.png")
+        return render_thumbnail(candidate, output)
 
     with get_sync_session() as db:
         model = db.query(Model).filter(Model.id == model_id_or_path).first()
         if not model or not model.file_path:
             logger.error(f"[Celery] Thumbnail task: model {model_id_or_path} not found or missing file_path")
             return None
-        return render_thumbnail(model.file_path)
+        thumb_path = Path(settings.uploads_path) / "users" / str(model.user_id) / "thumbnails" / f"{model.id}_thumb.png"
+        return render_thumbnail(Path(model.file_path), thumb_path)
 
 
 if __name__ == "__main__":

--- a/makerworks-backend/app/main.py
+++ b/makerworks-backend/app/main.py
@@ -167,11 +167,6 @@ logger.info(f"📂 Resolved absolute path: {uploads_path}")
 app.mount("/uploads", StaticFiles(directory=str(uploads_path), html=False, check_dir=True), name="uploads")
 logger.info(f"📁 Uploads served from {uploads_path} at /uploads")
 
-# ✅ Serve thumbnails via /media
-thumbnails_path = uploads_path / "thumbnails"
-thumbnails_path.mkdir(parents=True, exist_ok=True)
-app.mount("/media", StaticFiles(directory=str(thumbnails_path), html=False, check_dir=True), name="media")
-logger.info(f"📁 Thumbnails served from {thumbnails_path} at /media")
 
 # ─── Normalize Upload URL Handling ──────────
 @app.middleware("http")

--- a/makerworks-backend/app/routes/models.py
+++ b/makerworks-backend/app/routes/models.py
@@ -114,18 +114,19 @@ async def browse_all_filesystem_models(
                 meta = db_map.get(model_file.name)
                 username = meta["username"] if meta else user_dir.name
 
-                # ✅ Ensure thumbnail exists in global thumbnails folder
+                # ✅ Ensure thumbnail exists in user thumbnails folder
                 if not (meta and meta["thumbnail"]):
                     ensure_user_model_thumbnails_for_user(user_dir.name)
 
-                # ✅ Build thumbnail URL using only filename
+                # ✅ Build thumbnail URL relative to /uploads
                 thumb_url = None
                 if meta and meta["thumbnail"]:
-                    thumb_url = f"/media/{Path(meta['thumbnail']).name}"
+                    thumb_url = f"/uploads/{meta['thumbnail']}"
                 else:
-                    thumb_candidate = Path("app/uploads/thumbnails") / f"{model_file.stem}_thumb.png"
+                    thumb_candidate = uploads_root / "users" / user_dir.name / "thumbnails" / f"{model_file.stem}_thumb.png"
                     if thumb_candidate.exists():
-                        thumb_url = f"/media/{thumb_candidate.name}"
+                        rel_thumb = thumb_candidate.relative_to(uploads_root).as_posix()
+                        thumb_url = f"/uploads/{rel_thumb}"
 
                 # ✅ Build turntable URL safely
                 webm_url = None

--- a/makerworks-backend/app/routes/upload.py
+++ b/makerworks-backend/app/routes/upload.py
@@ -131,7 +131,7 @@ async def upload_model(
 
         try:
             generate_model_previews.apply_async(
-                args=[str(file_path), model_uuid, str(turntable_abs)],
+                args=[str(file_path), model_uuid, str(user_id), str(turntable_abs)],
                 task_id=str(uuid4())
             )
             logger.info("🎨 Queued preview generation for %s", model_uuid)

--- a/makerworks-backend/app/utils/users.py
+++ b/makerworks-backend/app/utils/users.py
@@ -47,7 +47,7 @@ def create_user_dirs(user_id: str) -> dict[str, bool]:
     base = Path(settings.uploads_path).resolve() / "users" / user_id
     results: dict[str, bool] = {}
 
-    for sub in ["avatars", "models"]:
+    for sub in ["avatars", "models", "thumbnails"]:
         path = base / sub
         try:
             path.mkdir(parents=True, exist_ok=True)

--- a/makerworks-backend/tests/test_upload_thumbnail.py
+++ b/makerworks-backend/tests/test_upload_thumbnail.py
@@ -112,6 +112,7 @@ def test_thumbnail_created(client, tmp_path):
     upload.render_thumbnail = original_render
 
     assert resp.status_code == 200
-    model_dir = Path(tmp_path) / "users" / str(user_id) / "models"
-    thumb = model_dir / "cube.png"
-    assert thumb.exists()
+    thumb_dir = Path(tmp_path) / "users" / str(user_id) / "thumbnails"
+    # Thumbnail uses generated UUID name; ensure directory is not empty
+    files = list(thumb_dir.glob("*.png"))
+    assert files


### PR DESCRIPTION
## Summary
- create `thumbnails` dirs when registering users
- render thumbnails directly into user folders
- update Celery tasks and worker to use new thumbnail paths
- normalize file URLs to `/uploads/...`
- remove old `/media` static mount
- update tests for new folder layout

## Testing
- `pip install -r requirements.txt` *(failed due to environment)*
- `pytest -q` *(failed: database not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_688d3f604564832fa76848e9c435e42a

## Summary by Sourcery

Reorganize upload and thumbnail storage structure under /uploads/users, refactor rendering utilities to use configurable paths, update tasks and routes to leverage per-user directories, normalize URLs to /uploads and remove legacy /media mount

Enhancements:
- Use per-user thumbnails directory under uploads/users/{user_id}/thumbnails and create it during user registration
- Update Celery tasks, API routes, and worker to pass user_id and render thumbnails and turntables into the new user-specific paths
- Refactor render_thumbnail and ensure_thumbnail utilities to accept explicit output_path based on settings.uploads_path
- Normalize all file and thumbnail URLs to /uploads/... and remove the deprecated /media static mount

Tests:
- Update tests to verify thumbnails are generated in the per-user thumbnails directory