### PR TITLE
fix: ensure backend Dockerfiles work without local env

### DIFF
--- a/Dockerfile.backend.macos
+++ b/Dockerfile.backend.macos
@@ -1,60 +1,70 @@
 # syntax=docker/dockerfile:1.5
 
 ##############################################
-# ===== Base Stage for macOS ARM64 =====
+# ===== macOS Backend (multi-arch) =====
 ##############################################
-FROM --platform=linux/arm64/v8 python:3.12-slim as base
+
+ARG TARGETPLATFORM
+FROM --platform=${TARGETPLATFORM:-linux/arm64} python:3.12-slim AS base
 
 WORKDIR /app
 
-# Install runtime & psycopg2 deps
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    libpq-dev \
-    libpq5 \
-    gcc \
-    curl \
-    libfreetype6-dev \
-    libpng-dev \
-    pkg-config \
-    python3-dev \
-    git \
-    postgresql-client \
- && rm -rf /var/lib/apt/lists/*
+# Install Postgres client with fallback and required build tools
+RUN apt-get update && \
+    (apt-get install -y --no-install-recommends \
+        build-essential \
+        libpq-dev \
+        libpq5 \
+        gcc \
+        musl-dev \
+        curl \
+        git \
+        libfreetype6-dev \
+        libpng-dev \
+        pkg-config \
+        python3-dev \
+        postgresql-client-15 \
+     || apt-get install -y --no-install-recommends postgresql-client) && \
+    rm -rf /var/lib/apt/lists/*
+
+# Verify pg_isready exists
+RUN command -v pg_isready || (echo "❌ pg_isready missing!" && exit 1)
 
 # Install Python deps
-COPY requirements.txt .
+COPY makerworks-backend/requirements.txt .
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --upgrade pip \
- && pip install --no-cache-dir psycopg2-binary>=2.9 \
- && pip install --no-cache-dir -r requirements.txt \
- && pip install --no-cache-dir gunicorn uvicorn
+    && pip install --no-cache-dir psycopg2-binary>=2.9 \
+    && pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir gunicorn uvicorn
 
 ##############################################
 # ===== Builder Stage =====
 ##############################################
-FROM base as builder
+ARG TARGETPLATFORM
+FROM --platform=${TARGETPLATFORM:-linux/arm64} base AS builder
 WORKDIR /app
 
-COPY alembic.ini /app/alembic.ini
-COPY alembic /app/alembic
-COPY .env.dev /app/.env.dev
-
-RUN test -f /app/.env.dev || touch /app/.env.dev
+COPY makerworks-backend/alembic.ini /app/alembic.ini
+COPY makerworks-backend/alembic /app/alembic
+COPY makerworks-backend/.env.example /app/.env.dev
 
 ##############################################
 # ===== Final Stage =====
 ##############################################
-FROM base as final
+ARG TARGETPLATFORM
+FROM --platform=${TARGETPLATFORM:-linux/arm64} base AS final
 WORKDIR /app
+
+ARG CACHE_BUST=1
 
 COPY --from=builder /usr/local /usr/local
 COPY --from=builder /app/alembic /app/alembic
 COPY --from=builder /app/alembic.ini /app/alembic.ini
 COPY --from=builder /app/.env.dev /app/.env.dev
 
-COPY ./app /app/app
-COPY ./docker-entrypoint.sh /app/docker-entrypoint.sh
+COPY makerworks-backend/app /app/app
+COPY makerworks-backend/docker-entrypoint.sh /app/docker-entrypoint.sh
 RUN chmod +x /app/docker-entrypoint.sh
 
 EXPOSE 8000

--- a/makerworks-backend/Dockerfile
+++ b/makerworks-backend/Dockerfile
@@ -30,8 +30,7 @@ RUN if [ "$WORKER_IMAGE" = "true" ]; then \
 COPY alembic.ini /app/alembic.ini
 COPY alembic /app/alembic
 
-COPY .env.dev /app/.env.dev
-RUN test -f /app/.env.dev || touch /app/.env.dev
+COPY .env.example /app/.env.dev
 
 ##############################################
 # ===== Runtime Stage =====

--- a/makerworks-backend/Dockerfile.macos
+++ b/makerworks-backend/Dockerfile.macos
@@ -46,8 +46,7 @@ WORKDIR /app
 
 COPY alembic.ini /app/alembic.ini
 COPY alembic /app/alembic
-COPY .env.dev /app/.env.dev
-RUN test -f /app/.env.dev || touch /app/.env.dev
+COPY .env.example /app/.env.dev
 
 ##############################################
 # ===== Final Stage =====


### PR DESCRIPTION
## Summary
- copy `.env.example` as `.env.dev` in backend Dockerfiles
- add multi-arch macOS Dockerfile that references backend paths

## Testing
- `pytest` *(fails: Database schema out of sync and async fixture issues)*

------
https://chatgpt.com/codex/tasks/task_e_688fc77daff8832fbbbfe04e137aec03