### PR TITLE
fix: ensure browse uses generated thumbnails

### DIFF
--- a/makerworks-backend/app/utils/filesystem.py
+++ b/makerworks-backend/app/utils/filesystem.py
@@ -36,23 +36,34 @@ def create_user_folders(user_id) -> dict[str, bool]:
 
 def ensure_user_model_thumbnails_for_user(user_id: str) -> None:
     """
-    Ensures all STL/3MF/OBJ models in a user's models folder have thumbnails.
-    Uses the unified render_thumbnail() which always writes to the global thumbnails folder.
+    Ensure each STL/3MF/OBJ model for ``user_id`` has a rendered thumbnail.
+
+    Thumbnails are written to ``uploads/users/{user_id}/thumbnails`` using the
+    pattern ``{model_id}_thumb.png`` so they can be served via ``/uploads`` and
+    discovered by the browse endpoint.
     """
+
     models_dir = UPLOADS_ROOT / "users" / str(user_id) / "models"
     if not models_dir.exists():
         logger.debug(f"[Thumbnail] No models directory for user {user_id}")
         return
+
+    thumbs_dir = UPLOADS_ROOT / "users" / str(user_id) / "thumbnails"
+    thumbs_dir.mkdir(parents=True, exist_ok=True)
 
     for model_file in models_dir.iterdir():
         if model_file.suffix.lower() not in {".stl", ".3mf", ".obj"}:
             continue
 
         model_id = model_file.stem
+        thumb_abs = thumbs_dir / f"{model_id}_thumb.png"
+        if thumb_abs.exists():
+            continue
+
         try:
             logger.info(f"[Thumbnail] Generating thumbnail for {model_file.name}")
-            thumb_path = render_thumbnail(model_file, model_id)
-            logger.debug(f"[Thumbnail] ✅ Generated thumbnail: {thumb_path}")
+            render_thumbnail(model_file, thumb_abs)
+            logger.debug(f"[Thumbnail] ✅ Generated thumbnail: {thumb_abs}")
         except Exception as e:
             # ✅ Avoid reentrant logging by not using logger.exception
             logger.error(f"[Thumbnail] ❌ Failed for {model_file.name}: {e}")

--- a/makerworks-backend/tests/test_filesystem.py
+++ b/makerworks-backend/tests/test_filesystem.py
@@ -1,14 +1,29 @@
 import os
+import sys
 import importlib
 import uuid
 from pathlib import Path
 
 import pytest
 
+# Ensure the backend package is importable
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+
+def _import_filesystem(monkeypatch, uploads_path: Path):
+    """Helper to import filesystem with required env variables."""
+    monkeypatch.setenv("UPLOADS_PATH", str(uploads_path))
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///test.db")
+    monkeypatch.setenv("ASYNC_DATABASE_URL", "sqlite+aiosqlite:///test.db")
+    sys.modules.pop("app.config.settings", None)
+    sys.modules.pop("app.utils.filesystem", None)
+    settings_module = importlib.import_module("app.config.settings")
+    importlib.reload(settings_module)
+    return importlib.reload(importlib.import_module("app.utils.filesystem"))
+
 
 def test_create_user_folders(tmp_path, monkeypatch):
-    monkeypatch.setenv("UPLOADS_PATH", str(tmp_path))
-    filesystem = importlib.reload(importlib.import_module("app.utils.filesystem"))
+    filesystem = _import_filesystem(monkeypatch, tmp_path)
 
     user_id = uuid.uuid4()
     result = filesystem.create_user_folders(user_id)
@@ -21,3 +36,27 @@ def test_create_user_folders(tmp_path, monkeypatch):
     assert models.exists()
     assert result[str(avatars)]
     assert result[str(models)]
+
+
+def test_ensure_user_model_thumbnails_for_user(tmp_path, monkeypatch):
+    """Thumbnails should be generated in the user's thumbnails folder."""
+    filesystem = _import_filesystem(monkeypatch, tmp_path)
+
+    user_id = "user1"
+    models_dir = Path(tmp_path) / "users" / user_id / "models"
+    models_dir.mkdir(parents=True, exist_ok=True)
+    model_file = models_dir / "cube.stl"
+    model_file.write_text("solid cube\nendsolid cube")
+
+    # Patch render_thumbnail to avoid heavy dependencies and create a dummy file
+    def fake_render(model_path, output_path, size=(1024, 1024)):
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(output_path).write_bytes(b"png")
+        return str(output_path)
+
+    monkeypatch.setattr(filesystem, "render_thumbnail", fake_render)
+
+    filesystem.ensure_user_model_thumbnails_for_user(user_id)
+
+    thumb = Path(tmp_path) / "users" / user_id / "thumbnails" / "cube_thumb.png"
+    assert thumb.exists(), "Thumbnail was not generated in expected location"


### PR DESCRIPTION
## Summary
- ensure filesystem thumbnail helper writes to user thumbnail folder
- add tests verifying thumbnails are created with `_thumb.png`

## Testing
- `pytest tests/test_filesystem.py::test_create_user_folders tests/test_filesystem.py::test_ensure_user_model_thumbnails_for_user -q`
- `pytest -q` *(fails: async def functions are not natively supported, ModelMetadata keyword errors, 12 failed, 10 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688fdc61f014832fb60d1b83eb3f2d1c

## Summary by Sourcery

Ensure model thumbnails are written and discovered in each user’s thumbnails folder and add tests to verify their creation

Bug Fixes:
- Write rendered thumbnails to uploads/users/{user_id}/thumbnails with the {model_id}_thumb.png pattern
- Skip regenerating thumbnails if they already exist

Enhancements:
- Create user thumbnails directory before generating thumbnails
- Simplify filesystem imports in tests by adding an _import_filesystem helper

Tests:
- Add test to verify user folders creation
- Add test to ensure thumbnails are generated in the user’s thumbnails folder