### PR TITLE
refactor: replace gradient styles with solid colors

### DIFF
--- a/makerworks-frontend/src/components/ui/GlassButton.tsx
+++ b/makerworks-frontend/src/components/ui/GlassButton.tsx
@@ -11,8 +11,7 @@ interface GlassButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>
 }
 
 const variants = {
-  primary:
-    'bg-gradient-to-r from-brand-red to-brand-white text-black hover:opacity-90',
+  primary: 'bg-brand-red text-brand-black hover:opacity-90',
   secondary:
     'bg-zinc-200/80 text-black dark:bg-zinc-700/70 dark:text-white hover:bg-zinc-300 dark:hover:bg-zinc-600',
   ghost:

--- a/makerworks-frontend/src/index.css
+++ b/makerworks-frontend/src/index.css
@@ -2,22 +2,22 @@
 @tailwind components;
 @tailwind utilities;
 
-/* 🌌 Global Gradient Backgrounds */
+/* 🌌 Global Background Colors */
 @layer base {
   html, body, #root {
     @apply min-h-screen;
   }
 
   body {
-    @apply transition-colors duration-500 text-brand-black;
-    background: linear-gradient(180deg, #FFFFFF 0%, #FF4F00 100%);
+    @apply transition-colors duration-500 text-brand-text;
+    background-color: #FFFFFF;
   }
 
-  /* 🌙 Dark Theme Gradient */
+  /* 🌙 Dark Theme */
   body.dark,
   .dark body {
     @apply text-brand-white;
-    background: linear-gradient(180deg, #000000 0%, #FF4F00 100%);
+    background-color: #000000;
   }
 }
 

--- a/makerworks-frontend/src/pages/Landing.tsx
+++ b/makerworks-frontend/src/pages/Landing.tsx
@@ -21,7 +21,7 @@ const Landing = () => {
   }, [hydrated, resolved, isAuthenticated, navigate])
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gradient-to-b from-white to-brand-red dark:from-brand-black dark:to-brand-red">
+    <div className="flex items-center justify-center min-h-screen bg-brand-white dark:bg-brand-black">
       <GlassCard>
         <div className="flex flex-col items-center justify-center text-center p-8">
           <h1 className="text-4xl font-bold mb-6">MakerW⚙️rks</h1>

--- a/makerworks-frontend/src/pages/PageNotFound.tsx
+++ b/makerworks-frontend/src/pages/PageNotFound.tsx
@@ -4,7 +4,7 @@ import { motion } from "framer-motion";
 
 export default function PageNotFound({ to = "/" }: { to?: string }) {
   return (
-    <main className="flex flex-col items-center justify-center h-screen text-center bg-gradient-to-br from-white to-brand-red dark:from-brand-black dark:to-brand-red">
+    <main className="flex flex-col items-center justify-center h-screen text-center bg-brand-white dark:bg-brand-black">
       <Helmet>
         <title>404 – Page Not Found</title>
         <meta name="robots" content="noindex" />
@@ -27,7 +27,7 @@ export default function PageNotFound({ to = "/" }: { to?: string }) {
         <Link
           to={to}
           aria-label="Go to Home"
-          className="mt-6 inline-block px-6 py-2 bg-gradient-to-r from-brand-red to-brand-white text-black rounded-full shadow-md hover:shadow-lg hover:scale-105 transition-transform"
+          className="mt-6 inline-block px-6 py-2 bg-brand-red text-brand-black rounded-full shadow-md hover:shadow-lg hover:scale-105 transition-transform"
         >
           ⬅ Go Home
         </Link>

--- a/makerworks-frontend/src/pages/Upload.tsx
+++ b/makerworks-frontend/src/pages/Upload.tsx
@@ -196,7 +196,7 @@ const UploadPage: React.FC = () => {
                 style={{
                   width: `${progress}%`,
                   height: '100%',
-                  background: 'linear-gradient(90deg, #FF6A1F, #C0C0C0)',
+                  background: '#FF4F00',
                   transition: 'width 0.2s ease'
                 }}
               />


### PR DESCRIPTION
## Summary
- replace gradient backgrounds with solid colors in global base styles
- remove gradient utilities from components in favor of palette colors

## Testing
- `npm test` *(fails: ZodError and Axios network errors)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f88d8e600832f8dc4b0b9d58aa80a