### PR TITLE
refactor: replace green styles with brand colors

### DIFF
--- a/makerworks-frontend/src/components/auth/SignIn.tsx
+++ b/makerworks-frontend/src/components/auth/SignIn.tsx
@@ -74,14 +74,14 @@ const SignIn: React.FC = () => {
           <button
             type="button"
             onClick={() => setShowPassword(!showPassword)}
-            className="absolute right-3 top-7 text-xs text-blue-600 hover:text-blue-800"
+            className="absolute right-3 top-7 text-xs text-brand-blue hover:text-brand-red"
           >
             {showPassword ? 'Hide' : 'Show'}
           </button>
         </div>
 
         <button
-          className="mt-4 rounded-full px-6 py-2 backdrop-blur-md bg-blue-200/30 border border-blue-300/30 shadow-inner shadow-blue-100/20 hover:bg-blue-200/50 hover:shadow-blue-200/30 text-blue-900 dark:text-blue-100 transition-all duration-200"
+          className="mt-4 rounded-full px-6 py-2 bg-brand-red text-brand-white hover:bg-brand-blue transition-colors duration-200 disabled:opacity-50"
           type="submit"
           disabled={loading}
         >
@@ -90,7 +90,7 @@ const SignIn: React.FC = () => {
 
         <p className="text-center text-sm mt-2">
           Not a member?{' '}
-          <Link to="/auth/signup" className="text-blue-600 hover:text-blue-800 font-medium underline">
+          <Link to="/auth/signup" className="text-brand-blue hover:text-brand-red font-medium underline">
             Sign up
           </Link>
         </p>

--- a/makerworks-frontend/src/components/auth/SignUp.tsx
+++ b/makerworks-frontend/src/components/auth/SignUp.tsx
@@ -126,8 +126,8 @@ const SignUp = () => {
             className={`input rounded-full px-4 py-2 pr-12 ${
               confirmPassword
                 ? passwordsMatch
-                  ? 'border-green-500 focus:ring-green-400'
-                  : 'border-red-500 focus:ring-red-400'
+                  ? 'border-brand-blue focus:ring-brand-blue'
+                  : 'border-brand-red focus:ring-brand-red'
                 : ''
             }`}
             placeholder="••••••••"
@@ -139,7 +139,7 @@ const SignUp = () => {
           <button
             type="button"
             onClick={() => setShowPassword(!showPassword)}
-            className="absolute right-3 top-7 text-xs text-blue-600 hover:text-blue-800"
+            className="absolute right-3 top-7 text-xs text-brand-blue hover:text-brand-red"
           >
             {showPassword ? 'Hide' : 'Show'}
           </button>
@@ -158,8 +158,8 @@ const SignUp = () => {
               className={`input rounded-full px-4 py-2 ${
                 confirmPassword
                   ? passwordsMatch
-                    ? 'border-green-500 focus:ring-green-400'
-                    : 'border-red-500 focus:ring-red-400'
+                    ? 'border-brand-blue focus:ring-brand-blue'
+                    : 'border-brand-red focus:ring-brand-red'
                   : ''
               }`}
               placeholder="Confirm your password"
@@ -186,16 +186,12 @@ const SignUp = () => {
             rounded-full
             px-6
             py-2
-            backdrop-blur-md
-            bg-blue-200/30
-            border border-blue-300/30
-            shadow-inner shadow-blue-100/20
-            hover:bg-blue-200/50
-            hover:shadow-blue-200/30
-            text-blue-900
-            dark:text-blue-100
-            transition-all
+            bg-brand-red
+            text-brand-white
+            hover:bg-brand-blue
+            transition-colors
             duration-200
+            disabled:opacity-50
           "
         >
           {loading ? 'Signing up…' : 'Sign Up'}

--- a/makerworks-frontend/src/components/layout/PageLayout.tsx
+++ b/makerworks-frontend/src/components/layout/PageLayout.tsx
@@ -100,7 +100,7 @@ export default function PageLayout({
                   {crumb.href ? (
                     <Link
                       to={crumb.href}
-                      className="hover:underline hover:text-blue-600 dark:hover:text-blue-400"
+                      className="hover:underline hover:text-brand-blue dark:hover:text-brand-red"
                     >
                       {crumb.label}
                     </Link>


### PR DESCRIPTION
## Summary
- replace green validation highlights with brand-red/brand-blue classes
- refresh auth buttons and links to brand color palette for contrast
- update breadcrumb hover colors to brand hues

## Testing
- `npm run lint`
- `npm test` *(fails: Unable to update item 'auth-storage'; network errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f8ad95a94832f8c673299ba466f14