### PR TITLE
Enforce upload path normalization

### DIFF
--- a/makerworks-backend/app/models/models.py
+++ b/makerworks-backend/app/models/models.py
@@ -167,12 +167,11 @@ def normalize_modelupload_paths(mapper, connection, target: ModelUpload):
         if not p.is_absolute():
             p = uploads_root / p
         try:
-            # store relative-to-root path (portable across hosts)
-            rel = p.relative_to(uploads_root).as_posix()
+            # Resolve to eliminate ".." and symlinks, then ensure within root
+            rel = p.resolve().relative_to(uploads_root).as_posix()
             return rel
-        except Exception:
-            logging.warning("⚠️ Path outside uploads root: %s (keeping as-is)", p)
-            return value
+        except Exception as exc:
+            raise ValueError(f"Path outside uploads root: {p}") from exc
 
     if target.file_path:
         target.file_path = normalize_path(target.file_path)

--- a/makerworks-backend/tests/test_filesystem.py
+++ b/makerworks-backend/tests/test_filesystem.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import importlib
 import uuid
 from pathlib import Path
 
@@ -8,6 +7,12 @@ import pytest
 
 # Ensure the backend package is importable
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///test.db")
+os.environ.setdefault("ASYNC_DATABASE_URL", "sqlite+aiosqlite:///test.db")
+
+import importlib
+import app.models.models as models_module
 
 
 def _import_filesystem(monkeypatch, uploads_path: Path):
@@ -20,6 +25,11 @@ def _import_filesystem(monkeypatch, uploads_path: Path):
     settings_module = importlib.import_module("app.config.settings")
     importlib.reload(settings_module)
     return importlib.reload(importlib.import_module("app.utils.filesystem"))
+
+
+@pytest.fixture(autouse=True)
+def _set_uploads_root(tmp_path):
+    models_module.uploads_root = tmp_path
 
 
 def test_create_user_folders(tmp_path, monkeypatch):
@@ -48,15 +58,29 @@ def test_ensure_user_model_thumbnails_for_user(tmp_path, monkeypatch):
     model_file = models_dir / "cube.stl"
     model_file.write_text("solid cube\nendsolid cube")
 
-    # Patch render_thumbnail to avoid heavy dependencies and create a dummy file
+    # Patch render_thumbnail importer to avoid heavy dependencies and create a dummy file
     def fake_render(model_path, output_path, size=(1024, 1024)):
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
         Path(output_path).write_bytes(b"png")
         return str(output_path)
 
-    monkeypatch.setattr(filesystem, "render_thumbnail", fake_render)
+    import types
+    monkeypatch.setitem(sys.modules, "app.utils.render_thumbnail", types.SimpleNamespace(render_thumbnail=fake_render))
 
     filesystem.ensure_user_model_thumbnails_for_user(user_id)
 
     thumb = Path(tmp_path) / "users" / user_id / "thumbnails" / "cube_thumb.png"
     assert thumb.exists(), "Thumbnail was not generated in expected location"
+
+
+def test_normalize_rejects_parent_paths():
+    with pytest.raises(ValueError):
+        target = models_module.ModelUpload(file_path="../evil.stl")
+        models_module.normalize_modelupload_paths(None, None, target)
+
+
+def test_normalize_rejects_outside_paths():
+    outside = models_module.uploads_root.parent / "evil.stl"
+    with pytest.raises(ValueError):
+        target = models_module.ModelUpload(file_path=str(outside))
+        models_module.normalize_modelupload_paths(None, None, target)


### PR DESCRIPTION
## Summary
- raise `ValueError` when `ModelUpload` paths resolve outside the configured uploads root
- add tests to ensure `..` segments or absolute paths outside the uploads directory are rejected

## Testing
- `cd makerworks-backend && python -m pytest tests/test_filesystem.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2659860f0832fa4f42cfe4fe667f1