### PR TITLE
Validate production secrets

### DIFF
--- a/makerworks-backend/.env.example
+++ b/makerworks-backend/.env.example
@@ -6,6 +6,10 @@ ENV_FILE=.env
 APP_NAME=MakerWorks API
 API_VERSION=0.1.0
 
+# 📄 Secrets
+SECRET_KEY=dev-secret-change-me        # change in production
+SESSION_SECRET=dev-secret-change-me    # change in production
+
 # 📄 Debug & Logging
 DEBUG=true                 # derived from ENV, kept here for convenience
 

--- a/makerworks-backend/README.md
+++ b/makerworks-backend/README.md
@@ -13,7 +13,9 @@ This is the FastAPI + Celery + PostgreSQL backend powering the MakerWorks 3D pri
 
 The repository ships with a `.env.example` file containing all the
 environment variables required to run the application. Copy it to `.env`
-and update the values for your environment.
+and update the values for your environment. For production deployments,
+**`SECRET_KEY`** and **`SESSION_SECRET`** must be set to non-default values or
+the application will raise an error on startup.
 
 Additional guidance on contributing new routes and features can be found in
 [docs/FUTURE_API_GUIDELINES.md](docs/FUTURE_API_GUIDELINES.md).


### PR DESCRIPTION
## Summary
- ensure `SECRET_KEY` and `SESSION_SECRET` cannot use default values in production
- document required secret variables in `.env.example` and backend README

## Testing
- `python -m pytest -q` *(fails: async def functions are not natively supported and other configuration errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a26893f1dc832f9d1fb7e16c4841a8

## Summary by Sourcery

Enforce non-default values for SECRET_KEY and SESSION_SECRET in production and update documentation accordingly

New Features:
- Validate that SECRET_KEY and SESSION_SECRET are not set to default values when ENV is production

Enhancements:
- Introduce DEFAULT_SECRET constant for shared default secret value

Documentation:
- Document required non-default SECRET_KEY and SESSION_SECRET in README and .env.example