### PR TITLE
Pin backend dependency versions

### DIFF
--- a/makerworks-backend/README.md
+++ b/makerworks-backend/README.md
@@ -58,5 +58,24 @@ with:
 docker-compose up prometheus grafana
 ```
 
+## Updating Dependencies
+
+Python packages are fully pinned in `requirements.txt` for reproducible
+builds. To bump a dependency:
+
+1. Edit `requirements.txt` with the new version.
+2. Rebuild the images so Docker picks up the change:
+
+   ```bash
+   make build-base && make fast-backend && make fast-worker
+   ```
+3. Run the test suite:
+
+   ```bash
+   pytest
+   ```
+
+No separate lockfile or hash file is used in this project.
+
 ## License
 MIT

--- a/makerworks-backend/requirements.txt
+++ b/makerworks-backend/requirements.txt
@@ -11,10 +11,10 @@ bcrypt==4.0.1
 cryptography==45.0.5
 ecdsa==0.19.1
 passlib==1.7.4
-PyJWT>=2.9
+PyJWT==2.10.1
 email-validator==2.2.0
 python-multipart==0.0.20
-itsdangerous>=2.1.2
+itsdangerous==2.2.0
 
 # ─── API Framework ──────────────────────────────────────────────────
 fastapi==0.116.1
@@ -63,17 +63,17 @@ aiofiles==23.2.1
 # ─── Image, Math, 3D Processing ─────────────────────────────────────
 matplotlib==3.10.3
 pillow==11.3.0
-numpy>=2.2,<2.3
+numpy==2.2.6
 scipy==1.14.1
 trimesh==4.7.1
 imageio[ffmpeg]==2.35.1
 
 # ✅ CPU renderer (headless)
-plotly>=5.23.0         # static image export via kaleido
+plotly==5.23.0         # static image export via kaleido
 kaleido==0.2.1         # pin for reproducible headless export
 
 # ✅ 3MF loader for trimesh
-meshio>=5.3            # enables trimesh to read .3mf files
+meshio==5.3.5            # enables trimesh to read .3mf files
 
 # ─── Stripe Integration ─────────────────────────────────────────────
 stripe==12.3.0


### PR DESCRIPTION
## Summary
- Pin PyJWT, itsdangerous, numpy, plotly, and meshio to exact versions
- Document how to update pinned dependencies

## Testing
- `pip install -r makerworks-backend/requirements.txt`
- `PYENV_VERSION=3.12.10 pytest` *(fails: No module named 'fakeredis')*


------
https://chatgpt.com/codex/tasks/task_e_68a51e89b638832f9d619c9588429684