### PR TITLE
refactor: centralize color palette usage

### DIFF
--- a/makerworks-frontend/src/index.css
+++ b/makerworks-frontend/src/index.css
@@ -9,6 +9,9 @@
   --mw-orange:#FF7A1A;
   --mw-green:#42FFA1;
   --mw-text:#2b2d31; /* primary text in light mode */
+  --mw-text-light:#E5E7EB; /* primary text on dark surfaces */
+  --mw-muted:#B6BBC6; /* muted text on dark surfaces */
+  --mw-navy:#0b0f1a; /* deep navy for dark surfaces */
 
   /* general rings */
   --mw-orange-inner: inset 0 0 12px rgba(255,122,26,.18), inset 0 0 2px rgba(255,122,26,.42);

--- a/makerworks-frontend/src/pages/Settings.tsx
+++ b/makerworks-frontend/src/pages/Settings.tsx
@@ -55,7 +55,7 @@ export default function Settings() {
       <div
         className="
           relative w-full max-w-md overflow-hidden rounded-[22px]
-          bg-white/65 dark:bg-[#0b0f1a]/55 backdrop-blur-2xl
+          bg-white/65 dark:bg-[var(--mw-navy)]/55 backdrop-blur-2xl
           shadow-[0_10px_40px_-10px_rgba(0,0,0,0.35)]
           ring-1 ring-white/25 dark:ring-white/10
           border border-white/25 dark:border-white/10
@@ -122,7 +122,7 @@ export default function Settings() {
           onClick={() => setShowAvatarEditor(false)}
         >
           <div
-            className="relative w-full max-w-sm overflow-hidden rounded-2xl bg-white/90 p-4 shadow-2xl ring-1 ring-white/40 backdrop-blur-2xl dark:bg-[#0b0f1a]/70 dark:ring-white/10"
+          className="relative w-full max-w-sm overflow-hidden rounded-2xl bg-white/90 p-4 shadow-2xl ring-1 ring-white/40 backdrop-blur-2xl dark:bg-[var(--mw-navy)]/70 dark:ring-white/10"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="absolute right-2 top-2">

--- a/makerworks-frontend/src/pages/Upload.tsx
+++ b/makerworks-frontend/src/pages/Upload.tsx
@@ -9,8 +9,6 @@ import { useDropzone } from 'react-dropzone'
 import toast, { Toaster } from 'react-hot-toast'
 import axios from '@/api/client'
 import { useAuthStore } from '@/store/useAuthStore'
-
-const ACCENT = '#FF7A1A'
 const allowedModelExtensions = ['stl', '3mf', 'obj']
 
 type PrintOrder = {
@@ -584,12 +582,12 @@ const UploadPage: React.FC = () => {
 
       <style>{`
         :root{
-          --vo-accent: ${ACCENT};
+          --vo-accent: var(--mw-orange);
           --vo-bg: rgba(255,255,255,0.06);
           --vo-stroke: rgba(255,255,255,0.14);
           --vo-soft: rgba(255,255,255,0.08);
-          --vo-text: #E5E7EB;
-          --vo-muted: #B6BBC6;
+          --vo-text: var(--mw-text-light);
+          --vo-muted: var(--mw-muted);
           --vo-shadow: 0 22px 80px rgba(0,0,0,.38), inset 0 1px 0 rgba(255,255,255,0.06);
           --ring-inner: inset 0 0 14px rgba(255,122,26,.18), inset 0 0 3px rgba(255,122,26,.42);
           --ring-outer: 0 0 14px rgba(255,122,26,.24), 0 0 40px rgba(255,122,26,.08);


### PR DESCRIPTION
## Summary
- use central palette variables for settings card backgrounds
- reference palette variables in upload styles and remove inline hex colors
- expose shared color tokens for dark surfaces and muted text

## Testing
- `npm run lint`
- `npm test` *(fails: signIn is not a function, updateUserProfile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a660e9e690832f89576d67ef38941d