### PR TITLE
Add CI workflow and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+title: "[Bug]: "
+---
+
+## Describe the bug
+A clear and concise description of what the bug is.
+
+## To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected behavior
+A clear and concise description of what you expected to happen.
+
+## Screenshots
+If applicable, add screenshots to help explain your problem.
+
+## Environment
+- OS: [e.g. Ubuntu 22.04]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
+
+## Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+title: "[Feature]: "
+---
+
+## Is your feature request related to a problem?
+A clear and concise description of what the problem is.
+
+## Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional context
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+Describe the changes in this pull request.
+
+## Testing
+- [ ] `pytest` (backend)
+- [ ] `npm test` (frontend)
+
+## Checklist
+- [ ] Tests added or updated
+- [ ] Linting and formatting run
+- [ ] Documentation updated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: makerworks-backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements.txt
+      - run: pytest
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: makerworks-frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - run: npm ci
+      - run: npm test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run backend pytest and frontend npm tests
- add bug report and feature request issue templates
- add pull request template with testing and docs checklist

## Testing
- `./makerworks-backend/.venv/bin/python -m pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6ed3ca444832fac6c44ce219cc82f