### PR TITLE
docs: add mobile build and test instructions

### DIFF
--- a/MakerWorks-Android/README.md
+++ b/MakerWorks-Android/README.md
@@ -10,6 +10,44 @@ An experimental Jetpack Compose client with a "visionOS glass" aesthetic. The ap
 4. Ensure a MakerWorks backend is running and update `FilamentService`'s `baseUrl` if not using `http://localhost:8000`.
 5. Connect an Android device or start an emulator with camera support and run the **app** configuration.
 
+## Testing
+
+Run unit tests with:
+
+```sh
+./gradlew test
+```
+
+To execute instrumented tests on a connected device or emulator run:
+
+```sh
+./gradlew connectedAndroidTest
+```
+
+## Building APKs
+
+Generate a debug build with:
+
+```sh
+./gradlew assembleDebug
+```
+
+For release builds, create either an APK or App Bundle:
+
+```sh
+./gradlew assembleRelease   # APK
+./gradlew bundleRelease     # AAB
+```
+
+Artifacts are written under `app/build/outputs/`.
+
+## Play Store Deployment
+
+1. Make sure the project is configured with a release signing key or Play App Signing.
+2. Run `./gradlew bundleRelease` to produce an uploadable App Bundle.
+3. Sign in to the [Google Play Console](https://play.google.com/console/), create a new release and upload the generated `.aab` file.
+4. Complete the release notes and roll out to testers or production.
+
 ## Barcode Format
 
 Barcodes should encode `type|color|hex` strings. For example, scanning `PLA|Red|#FF0000` will create a red PLA filament. Adjust the parsing in `FilamentService` if your format differs.

--- a/MakerWorks-iOS/README.md
+++ b/MakerWorks-iOS/README.md
@@ -10,5 +10,29 @@ An experimental SwiftUI iPhone client for the MakerWorks platform. The app showc
 ## Running
 Open the `Package.swift` in Xcode 15 or later and run the **MakerWorks** scheme on an iOS 17+ simulator or device. Update `API.baseURL` and authentication to match your deployment.
 
+## Testing
+
+Run unit tests from the command line with `xcodebuild`:
+
+```sh
+xcodebuild -scheme MakerWorks -destination 'platform=iOS Simulator,name=iPhone 15' test
+```
+
+You can also execute tests in Xcode via **Product → Test**.
+
+## TestFlight Distribution
+
+1. Archive the app:
+
+   ```sh
+   xcodebuild -scheme MakerWorks -configuration Release -archivePath build/MakerWorks.xcarchive archive
+   ```
+2. Export an IPA and upload it to App Store Connect using Xcode's Organizer or `xcrun altool`.
+3. In App Store Connect, create a TestFlight build and add testers.
+
+## Signing
+
+Set the project to use your Apple Developer Team under **Signing & Capabilities**. For automated builds, ensure a matching provisioning profile and signing certificate are available or use Xcode's automatic signing.
+
 ## Scanning
 Barcodes are interpreted as `type|color|hex` strings. For example, scanning a code that encodes `PLA|Red|#FF0000` will create a PLA filament with red color. Adjust the parsing logic in `FilamentService` as needed to match your barcode format.


### PR DESCRIPTION
## Summary
- document Android testing, release build, and Play Store steps
- add iOS xcodebuild tests, TestFlight, and signing guidance

## Testing
- `npm --prefix makerworks-frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a6fe9b7454832f87d3de33c8c5316b